### PR TITLE
Further handlebars updates cd

### DIFF
--- a/controllers/api/jobRoutes.js
+++ b/controllers/api/jobRoutes.js
@@ -22,4 +22,24 @@ router.post('/', async(req, res) => {
     }
 });
 
+router.delete('/:id', async(req, res) => {
+    try {
+        const jobData = await Job.destroy({
+            where: {
+                id: req.params.id,
+                user_id: req.session.user_id,
+            },
+        });
+
+        if (!jobData) {
+            res.status(404).json({ message: "No job with this id!" });
+            return;
+        }
+
+        res.status(200).json(jobData)
+    } catch (err) {
+        res.status(500).json(err);
+    }
+});
+
 module.exports = router

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -38,6 +38,10 @@ p {
     font-size: 18px;
 }
 
+a {
+    text-decoration: none;
+}
+
 
 /* pseudo selectors and styling */
 
@@ -197,10 +201,6 @@ header a:hover {
 
 #jobs-messages-margin {
     margin: 20px;
-}
-
-#skill-swap {
-    font-weight: bolder;
 }
 
 

--- a/public/js/deleteJob.js
+++ b/public/js/deleteJob.js
@@ -1,0 +1,23 @@
+const deleteHandler = async (event) => {
+    if (event.target.hasAttribute('data-id')) {
+        const id = event.target.getAttribute('data-id');
+
+        const response = await fetch(`/api/jobs/${id}`, {
+            method: 'DELETE',
+        });
+
+        if (response.ok) {
+            document.location.replace('/');
+        } else {
+            deleteFailed.innerHTML = "Could not delete this job. Please try again";
+        }
+    }
+};
+
+const deleteBtns = document.querySelectorAll('.delete-btn');
+
+for (var i = 0; i < deleteBtns.length; i++) {
+    deleteBtns[i].addEventListener('click', deleteHandler);
+};
+
+var deleteFailed = document.querySelector('#delete-failed');

--- a/views/dashboard.handlebars
+++ b/views/dashboard.handlebars
@@ -66,6 +66,8 @@
                 <a href="/jobs/{{job.id}}">
                     <button type="button" class="btn btn-style">More info</button>
                 </a>
+                <button type="button" class="btn btn-style delete-btn" data-id="{{job.id}}">Delete</button>
+                <p><span id="delete-failed"></span></p>
             </div>
             {{/each}}
             {{else}}
@@ -81,65 +83,4 @@
     </div>
 </div>
 
-<!-- List jobs that user's have selected to complete -->
-<div class="row row-adjust d-flex justify-content-center align-items-center" id="jobs-messages-margin">
-    <div class="col-12 jobs-column-style">
-        <h2 class="dashboard-heading" id="jobs-to-do">
-            Jobs to do
-        </h2>
-
-        <div class="row row-adjust row-style d-flex justify-content-center align-items-center text-center">
-            <div class="col-12 col-lg-5 my-job-card">
-                <h3 class="my-job-card-heading">
-                    Paint fence
-                </h3>
-                <p class="my-job-card-username">
-                    Username
-                </p>
-                <p>
-                    30 minutes
-                </p>
-                <button type="button" class="btn btn-style">See more</button>
-            </div>
-
-            <div class="col-12 col-lg-5 my-job-card">
-                <h3 class="my-job-card-heading">
-                    Tip run
-                </h3>
-                <p class="my-job-card-username">
-                    Username
-                </p>
-                <p>
-                    20 minutes
-                </p>
-                <button type="button" class="btn btn-style">See more</button>
-            </div>
-
-            <div class="col-12 col-lg-5 my-job-card">
-                <h3 class="my-job-card-heading">
-                    Walk dog
-                </h3>
-                <p class="my-job-card-username">
-                    Username
-                </p>
-                <p>
-                    10 minutes
-                </p>
-                <button type="button" class="btn btn-style">See more</button>
-            </div>
-
-            <div class="col-12 col-lg-5 my-job-card">
-                <h3 class="my-job-card-heading">
-                    Create website
-                </h3>
-                <p class="my-job-card-username">
-                    Username
-                </p>
-                <p>
-                    60 minutes
-                </p>
-                <button type="button" class="btn btn-style">See more</button>
-            </div>
-        </div>
-    </div>
-</div>
+<script src="/js/deleteJob.js"></script>

--- a/views/singleJob.handlebars
+++ b/views/singleJob.handlebars
@@ -32,18 +32,6 @@
 
         <div class="row row-adjust">
             <div class="col-12 text-center">
-                <p>
-                    <span id="skill-swap">Skill swap:</span> skill here
-                </p>
-            </div>
-        </div>
-
-        <div class="row row-adjust">
-            <div class="col-12 col-lg-6 text-center">
-                <button type="button" class="btn btn-style accept-job">Accept job</button>
-            </div>
-
-            <div class="col-12 col-lg-6 text-center">
                 <a href="mailto:{{job.user.email}}">
                     <button type="button" class="btn btn-style accept-job">Contact user</button>
                 </a>


### PR DESCRIPTION
Main updates:

- Updated jobRoutes.js to include a DELETE route for jobs posted by a user
- Added deleteJob.js public script to handle the deleting of jobs when pressing the 'delete' button
- Removed 'Accept job' button from the single jobs, leaving only 'contact'. This will mean the user will contact the job poster directly the accept the job. The job poster can then delete the job ad once it's been accepted and completed.
- Updated CSS for styling (more info + delete button next to each other caused weird styling issues)
- Removed 'jobs to do' section of the dashboard as currently no functionality to list the jobs 'accepted'. Will include this in future developments