### PR TITLE
Removed link on dashboard for jobs to do

### DIFF
--- a/views/dashboard.handlebars
+++ b/views/dashboard.handlebars
@@ -18,11 +18,6 @@
                     View my posted jobs
                 </li>
             </a>
-            <a href="#jobs-to-do" class="dashboard-link-style" id="users-jobs">
-                <li class="dashboard-individual-links">
-                    View jobs to do
-                </li>
-            </a>
             <a href="/jobs" class="dashboard-link-style">
                 <li class="dashboard-individual-links">
                     View all available jobs


### PR DESCRIPTION
Main update:

- Removed the link on the dashboard to view "jobs to do" as this section of the page doesn't exist anymore