### PR TITLE
Adding withAuth functionality to individual jobs

### DIFF
--- a/controllers/homeRoutes.js
+++ b/controllers/homeRoutes.js
@@ -56,7 +56,7 @@ router.get('/jobs', async(req, res) => {
 
 
 // Use withAuth middleware to prevent access to route, single job route
-router.get('/jobs/:id', async(req, res) => {
+router.get('/jobs/:id', withAuth, async(req, res) => {
     try {
         const jobData = await Job.findByPk(req.params.id, {
             include: [


### PR DESCRIPTION
Main update:

- Added withAuth to individual job GET route, so users not signed in will be able to view ALL jobs but won't be able to click through for more info on individual jobs. Instead, they'll be redirected to sign in.